### PR TITLE
add offline listener to remove offline nextHops

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,5 +23,6 @@ repositories {
 
 dependencies {
     compile('org.springframework.boot:spring-boot-starter-websocket')
+    compile('org.springframework.security.oauth:spring-security-oauth2')
     testCompile('org.springframework.boot:spring-boot-starter-test')
 }

--- a/src/main/java/com/jwrp/javawebsocketreverseproxy/WebSocketProxyClientHandler.java
+++ b/src/main/java/com/jwrp/javawebsocketreverseproxy/WebSocketProxyClientHandler.java
@@ -1,5 +1,6 @@
 package com.jwrp.javawebsocketreverseproxy;
 
+import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.WebSocketMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.AbstractWebSocketHandler;
@@ -10,13 +11,26 @@ import org.springframework.web.socket.handler.AbstractWebSocketHandler;
 public class WebSocketProxyClientHandler extends AbstractWebSocketHandler {
 
     private final WebSocketSession webSocketServerSession;
+    private final ClientOfflineListener listener;
 
-    public WebSocketProxyClientHandler(WebSocketSession webSocketServerSession) {
+    public WebSocketProxyClientHandler(WebSocketSession webSocketServerSession, ClientOfflineListener listener) {
         this.webSocketServerSession = webSocketServerSession;
+        this.listener = listener;
     }
 
     @Override
     public void handleMessage(WebSocketSession session, WebSocketMessage<?> webSocketMessage) throws Exception {
         webSocketServerSession.sendMessage(webSocketMessage);
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+        super.afterConnectionClosed(session, status);
+        // notify client has been offline, upstream client should exit.
+        listener.clientOffline();
+    }
+
+    public interface ClientOfflineListener{
+        void clientOffline();
     }
 }


### PR DESCRIPTION
This repo helps me a lot. Thanks for the author.

During the test, I found that the size of `NextHops ` map was increasing continuously, since we never remove `NextHop` even after socket session closed. This may cause memory problems after a long time running.

Therefore, I'd like to add a `ClientOfflineListener `to clear offline `NextHop `in the map.